### PR TITLE
Fix asc helper to avoid mutating input

### DIFF
--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -133,7 +133,7 @@ export const intersect2D = (a0: XY, a1: XY, b0: XY, b1: XY): Intersect2DResult =
     return new Intersect2DResult(EIntersectionType.INTERSECTION_OUTSIDE_SEGMENT, px, py);
 };
 
-export const asc = (arr: number[]) => arr.sort((a, b) => a - b);
+export const asc = (arr: number[]) => [...arr].sort((a, b) => a - b);
 
 export const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
 


### PR DESCRIPTION
## Summary
- adjust `asc` in `src/utils/math.ts` to return a sorted copy instead of mutating the caller’s array
- prevents `quantile`/`qXX` helpers from unexpectedly reordering their input

## Testing
- Not run locally (Bun CLI missing in my environment)
